### PR TITLE
Make it possible to view more variables at once

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,33 +25,34 @@ v-app.app.pr-3
               v-bind:uid="i + '-' + j",
               :currentTimeStep.sync="currentTimeStep")
       // Playback controls.
-      v-layout(row fluid).mt-0.mb-0
-        v-flex(xs1)
-          div.text-xs-center
-            v-btn(v-on:click="decrementTimeStep(true)"
-                  :disabled="!dataLoaded"
-                  flat icon small)
-              v-icon arrow_back_ios
-        v-flex(xs10)
-          v-slider(v-model="currentTimeStep"
-                   :max="maxTimeStep"
-                   :disabled="!dataLoaded"
-                   width="100%"
-                   height="1px"
-                   thumb-label="always")
-        v-flex(xs1)
-          div.text-xs-center
-            v-btn(v-on:click="incrementTimeStep(true)"
-                  :disabled="!dataLoaded"
-                  flat icon small)
-              v-icon arrow_forward_ios
-      v-layout(row fluid).mt-0.mb-0
-        v-flex(xs12)
-          div.controls.text-xs-center
-            button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
-            button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
-              span(v-show="paused") &#9654;
-              span(v-show="!paused") &#9208;
+      div.playback-controls
+        v-layout(row fluid).mt-0.mb-0
+          v-flex(xs1)
+            div.text-xs-center
+              v-btn(v-on:click="decrementTimeStep(true)"
+                    :disabled="!dataLoaded"
+                    flat icon small)
+                v-icon arrow_back_ios
+          v-flex(xs10)
+            v-slider(v-model="currentTimeStep"
+                     :max="maxTimeStep"
+                     :disabled="!dataLoaded"
+                     width="100%"
+                     height="1px"
+                     thumb-label="always")
+          v-flex(xs1)
+            div.text-xs-center
+              v-btn(v-on:click="incrementTimeStep(true)"
+                    :disabled="!dataLoaded"
+                    flat icon small)
+                v-icon arrow_forward_ios
+        v-layout(row fluid).mt-0.mb-0
+          v-flex(xs12)
+            div.controls.text-xs-center
+              button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
+              button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
+                span(v-show="paused") &#9654;
+                span(v-show="!paused") &#9208;
 </template>
 
 <script>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -16,15 +16,14 @@ v-app.app.pr-3
           :new-folder-enabled="false",
           :draggable="true")
     // Everything else on the right.
-    v-flex(xs10)
-      // 2x2 image gallery.
+    v-flex.main-content(xs10)
+      // image gallery grid.
       template(v-for="i in numrows")
         v-layout(row)
           template(v-for="j in numcols")
-            v-flex(xs6)
-              image-gallery(
-                v-bind:uid="i + '-' + j",
-                :currentTimeStep.sync="currentTimeStep")
+            image-gallery(
+              v-bind:uid="i + '-' + j",
+              :currentTimeStep.sync="currentTimeStep")
       // Playback controls.
       v-layout(row fluid).mt-0.mb-0
         v-flex(xs1)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -14,7 +14,7 @@ v-app.app.pr-3
         :forgot-password-url="forgotPasswordUrl")
   v-layout(row fluid)
     // Navigation panel on the left.
-    v-flex(xs3)
+    v-flex(xs2)
       girder-data-browser(ref="girderBrowser",
           v-if="location",
           :location.sync="location",
@@ -23,7 +23,7 @@ v-app.app.pr-3
           :new-folder-enabled="false",
           :draggable="true")
     // Everything else on the right.
-    v-flex(xs9)
+    v-flex(xs10)
       // 2x2 image gallery.
       template(v-for="i in numrows")
         v-layout(row)

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -73,6 +73,8 @@ v-app.app.pr-3
                     :disabled="numcols > 7"
                     flat icon small)
                 span +
+              v-btn(flat icon small @click="girderRest.logout()")
+                v-icon $vuetify.icons.logout
 </template>
 
 <script>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,12 +1,5 @@
 <template lang="pug">
 v-app.app.pr-3
-  // Header bar with "Logout" button
-  v-toolbar
-    v-spacer
-    v-toolbar-items
-      v-layout.pt-3(row, align-center, justify-center)
-      v-btn(flat, icon, @click="girderRest.logout()")
-        v-icon $vuetify.icons.logout
   v-dialog(:value="loggedOut", persistent, full-width, max-width="600px")
     girder-auth(
         :register="true",
@@ -33,24 +26,27 @@ v-app.app.pr-3
                 v-bind:uid="i + '-' + j",
                 :currentTimeStep.sync="currentTimeStep")
       // Playback controls.
-      v-layout(row fluid).mt-3.mb-0
+      v-layout(row fluid).mt-0.mb-0
         v-flex(xs1)
-          v-btn(v-on:click="decrementTimeStep(true)"
-                :disabled="!dataLoaded"
-                flat icon)
-            v-icon arrow_back_ios
+          div.text-xs-center
+            v-btn(v-on:click="decrementTimeStep(true)"
+                  :disabled="!dataLoaded"
+                  flat icon small)
+              v-icon arrow_back_ios
         v-flex(xs10)
           v-slider(v-model="currentTimeStep"
                    :max="maxTimeStep"
                    :disabled="!dataLoaded"
                    width="100%"
+                   height="1px"
                    thumb-label="always")
         v-flex(xs1)
-          v-btn(v-on:click="incrementTimeStep(true)"
-                :disabled="!dataLoaded"
-                flat icon)
-            v-icon arrow_forward_ios
-      v-layout(row fluid).mt-0
+          div.text-xs-center
+            v-btn(v-on:click="incrementTimeStep(true)"
+                  :disabled="!dataLoaded"
+                  flat icon small)
+              v-icon arrow_forward_ios
+      v-layout(row fluid).mt-0.mb-0
         v-flex(xs12)
           div.controls.text-xs-center
             button(v-on:click="togglePlayPause" :disabled="!dataLoaded")

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -25,7 +25,9 @@ v-app.app.pr-3
               v-flex(v-bind:style="{ width: cellWidth, height: cellHeight }")
                 image-gallery(
                   v-bind:uid="i + '-' + j",
-                  :currentTimeStep.sync="currentTimeStep")
+                  :currentTimeStep.sync="currentTimeStep",
+                  :numCells.sync="numCells",
+                  )
       // Playback controls.
       div.playback-controls
         v-layout(row fluid).mt-0.mb-0
@@ -105,6 +107,7 @@ export default {
       dataLoaded: false,
       forgotPasswordUrl: '/#?dialog=resetpassword',
       maxTimeStep: 0,
+      numCells: 1,
       numrows: 1,
       numcols: 1,
       paused: true,
@@ -180,10 +183,16 @@ export default {
 
     updateCellWidth() {
       this.cellWidth = (100 / this.numcols) + "%";
+      this.updateNumCells();
     },
 
     updateCellHeight() {
       this.cellHeight = (100 / this.numrows) + "vh";
+      this.updateNumCells();
+    },
+
+    updateNumCells() {
+      this.numCells = this.numrows * this.numcols;
     },
   },
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -47,12 +47,32 @@ v-app.app.pr-3
                     flat icon small)
                 v-icon arrow_forward_ios
         v-layout(row fluid).mt-0.mb-0
-          v-flex(xs12)
+          v-flex(shrink)
+              v-btn(v-on:click="removeRow()"
+                    :disabled="numrows < 2"
+                    flat icon small)
+                span -
+              span rows
+              v-btn(v-on:click="addRow()"
+                    :disabled="numrows > 7"
+                    flat icon small)
+                span +
+          v-flex(grow)
             div.controls.text-xs-center
               button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
               button(v-on:click="togglePlayPause" :disabled="!dataLoaded")
                 span(v-show="paused") &#9654;
                 span(v-show="!paused") &#9208;
+          v-flex(shrink)
+              v-btn(v-on:click="removeColumn()"
+                    :disabled="numcols < 2"
+                    flat icon small)
+                span -
+              span cols
+              v-btn(v-on:click="addColumn()"
+                    :disabled="numcols > 7"
+                    flat icon small)
+                span +
 </template>
 
 <script>
@@ -86,6 +106,14 @@ export default {
   },
 
   methods: {
+    addColumn() {
+      this.numcols += 1;
+    },
+
+    addRow() {
+      this.numrows += 1;
+    },
+
     decrementTimeStep(should_pause) {
       this.currentTimeStep -= 1;
       if (this.currentTimeStep < 0) {
@@ -112,6 +140,14 @@ export default {
       }
       this.dataLoaded = true;
       this.maxTimeStep = num_timesteps - 1;
+    },
+
+    removeColumn() {
+      this.numcols -= 1;
+    },
+
+    removeRow() {
+      this.numrows -= 1;
     },
 
     tick() {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -18,12 +18,14 @@ v-app.app.pr-3
     // Everything else on the right.
     v-flex.main-content(xs10)
       // image gallery grid.
-      template(v-for="i in numrows")
-        v-layout(row)
-          template(v-for="j in numcols")
-            image-gallery(
-              v-bind:uid="i + '-' + j",
-              :currentTimeStep.sync="currentTimeStep")
+      v-layout(column)
+        template(v-for="i in numrows")
+          v-layout
+            template(v-for="j in numcols")
+              v-flex(v-bind:style="{ width: cellWidth, height: cellHeight }")
+                image-gallery(
+                  v-bind:uid="i + '-' + j",
+                  :currentTimeStep.sync="currentTimeStep")
       // Playback controls.
       div.playback-controls
         v-layout(row fluid).mt-0.mb-0
@@ -97,12 +99,14 @@ export default {
   data() {
     return {
       browserLocation: null,
+      cellWidth: '100%',
+      cellHeight: '100vh',
       currentTimeStep: 0,
       dataLoaded: false,
       forgotPasswordUrl: '/#?dialog=resetpassword',
       maxTimeStep: 0,
-      numrows: 2,
-      numcols: 2,
+      numrows: 1,
+      numcols: 1,
       paused: true,
     };
   },
@@ -110,10 +114,12 @@ export default {
   methods: {
     addColumn() {
       this.numcols += 1;
+      this.updateCellWidth();
     },
 
     addRow() {
       this.numrows += 1;
+      this.updateCellHeight();
     },
 
     decrementTimeStep(should_pause) {
@@ -146,10 +152,12 @@ export default {
 
     removeColumn() {
       this.numcols -= 1;
+      this.updateCellWidth();
     },
 
     removeRow() {
       this.numrows -= 1;
+      this.updateCellHeight();
     },
 
     tick() {
@@ -168,6 +176,14 @@ export default {
       if (!this.paused) {
         this.tick();
       }
+    },
+
+    updateCellWidth() {
+      this.cellWidth = (100 / this.numcols) + "%";
+    },
+
+    updateCellHeight() {
+      this.cellHeight = (100 / this.numrows) + "vh";
     },
   },
 

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -1,7 +1,6 @@
 <template lang="pug">
 v-card.vertical-center(
-       height="300px" min-height="300px"
-       width="300px"  min-width="300px"
+       height="100%"
        v-on:drop="loadGallery($event)"
        v-on:dragover="preventDefault($event)")
   v-card-text.text-xs-center

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
-v-card.vertical-center(height="300px"
+v-card.vertical-center(
+       height="300px" min-height="300px"
+       width="300px"  min-width="300px"
        v-on:drop="loadGallery($event)"
        v-on:dragover="preventDefault($event)")
   v-card-title(v-if="item") {{item.name}}

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -8,7 +8,6 @@ v-card.vertical-center(
       div(v-bind:class="'gallery-' + uid")
         div.slide(v-for="row in rows")
           img(v-bind:data-lazy="row.img")
-          p {{row.name}}
     v-icon(v-if="!itemId" large) input
 </template>
 

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -24,6 +24,11 @@ export default {
       required: true
     },
 
+    numCells: {
+      type: Number,
+      required: true
+    },
+
     uid: {
       type: String,
       required: true
@@ -35,7 +40,7 @@ export default {
   data() {
     return {
       itemId: null,
-      itemIdChanged: true,
+      needsReRender: true,
       galleryRendered: false,
       rows: [],
     };
@@ -75,7 +80,16 @@ export default {
     itemId: {
       immediate: true,
       handler () {
-        this.itemIdChanged = true;
+        this.needsReRender = true;
+      }
+    },
+    numCells: {
+      immediate: true,
+      handler () {
+        this.needsReRender = true;
+        if (this.galleryRendered) {
+          this.renderGallery();
+        }
       }
     },
     uid: {
@@ -87,20 +101,7 @@ export default {
   },
 
   updated () {
-    if (!this.itemIdChanged || this.rows.length < 1) {
-      return;
-    }
-    if (this.galleryRendered) {
-      $(this.selector).slick('unslick');
-    }
-    $(this.selector).slick({
-      arrows: false,
-      autoplay: false,
-      dots: false,
-      lazyLoad: 'anticipated',
-    });
-    this.galleryRendered = true;
-    this.itemIdChanged = false;
+    this.renderGallery();
   },
 
   methods: {
@@ -113,6 +114,25 @@ export default {
       var items = JSON.parse(event.dataTransfer.getData('application/x-girder-items'));
       this.itemId = items[0];
     },
+
+    renderGallery: function () {
+      if (!this.needsReRender || this.rows.length < 1) {
+        return;
+      }
+      if (this.galleryRendered) {
+        $(this.selector).slick('unslick');
+      }
+      $(this.selector).slick({
+        arrows: false,
+        autoplay: false,
+        dots: false,
+        lazyLoad: 'anticipated',
+      });
+      $(this.selector).slick('slickGoTo', this.currentTimeStep, true);
+      this.galleryRendered = true;
+      this.needsReRender = false;
+    },
+
   },
 };
 </script>

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -4,7 +4,6 @@ v-card.vertical-center(
        width="300px"  min-width="300px"
        v-on:drop="loadGallery($event)"
        v-on:dragover="preventDefault($event)")
-  v-card-title(v-if="item") {{item.name}}
   v-card-text.text-xs-center
     div(v-if="itemId")
       div(v-bind:class="'gallery-' + uid")
@@ -36,7 +35,6 @@ export default {
 
   data() {
     return {
-      item: null,
       itemId: null,
       itemIdChanged: true,
       galleryRendered: false,

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -58,7 +58,12 @@ div.controls button {
   height: 100%;
 }
 
+// Make text smaller in the data browser.
 table.v-table tbody td {
   font-size: 0.5rem;
 }
 
+// Scroll horizontal scrollbar for gallery grid.
+.main-content {
+  overflow-x: scroll;
+}

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -67,3 +67,12 @@ table.v-table tbody td {
 .main-content {
   overflow-x: scroll;
 }
+
+// Float the control panel at the bottom of the screen.
+.playback-controls {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(225, 225, 225, 0.375);
+}

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -1,45 +1,3 @@
-ul.gallery-dots {
-  width: 100%;
-  display: table;
-  table-layout: fixed;
-  padding-left: 30px;
-  padding-right: 30px;
-
-  li {
-    display: table-cell;
-    width: auto;
-    text-align: center;
-
-    button {
-      background-color: #eee;
-      cursor: pointer;
-      height: 10px;
-      width: 10px;
-      font-size: 0;
-      &:hover {
-        background-color: #000;
-      }
-    }
-  }
-  li.slick-active button {
-    background-color: #000;
-  }
-}
-
-.slide img {
-  display: block;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.slide p {
-  text-align: center;
-}
-
-.slick-dotted.slick-slider {
-  margin-bottom: 0px;
-}
-
 div.controls button {
   margin: auto;
   display: block;
@@ -49,6 +7,7 @@ div.controls button {
   }
 }
 
+// Used to align the "Drop here" icon
 .vertical-center {
   display: flex;
   align-items: center;

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -35,3 +35,7 @@ table.v-table tbody td {
   right: 0;
   background: rgba(225, 225, 225, 0.375);
 }
+
+.slick-slide img {
+  margin: auto;
+}

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -38,4 +38,6 @@ table.v-table tbody td {
 
 .slick-slide img {
   margin: auto;
+  width: 100%;
+  object-fit: contain;
 }

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -57,3 +57,8 @@ div.controls button {
 .v-card * {
   height: 100%;
 }
+
+table.v-table tbody td {
+  font-size: 0.5rem;
+}
+


### PR DESCRIPTION
Previously the dashboard was hardcoded as a 2x2 grid. Now the user can add rows and columns as they see fit.

This PR also reduces the amount of screen real estate dedicated to the girder browser, and makes the playback control panel a floating, translucent section at the bottom of the page.