### PR TITLE
Stream new timesteps as they arrive

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -36,6 +36,7 @@ v-app.app.pr-3
                 v-icon arrow_back_ios
           v-flex(xs10)
             v-slider(v-model="currentTimeStep"
+                     :min="1"
                      :max="maxTimeStep"
                      :disabled="!dataLoaded"
                      width="100%"
@@ -100,7 +101,7 @@ export default {
       browserLocation: null,
       cellWidth: '100%',
       cellHeight: '100vh',
-      currentTimeStep: 0,
+      currentTimeStep: 1,
       dataLoaded: false,
       forgotPasswordUrl: '/#?dialog=resetpassword',
       maxTimeStep: 0,
@@ -123,9 +124,8 @@ export default {
     },
 
     decrementTimeStep(should_pause) {
-      this.currentTimeStep -= 1;
-      if (this.currentTimeStep < 0) {
-        this.currentTimeStep = this.maxTimeStep;
+      if (this.currentTimeStep > 1) {
+        this.currentTimeStep -= 1;
       }
       if (should_pause) {
         this.paused = true;
@@ -133,9 +133,8 @@ export default {
     },
 
     incrementTimeStep(should_pause) {
-      this.currentTimeStep += 1;
-      if (this.currentTimeStep > this.maxTimeStep) {
-        this.currentTimeStep = this.maxTimeStep;
+      if (this.currentTimeStep < this.maxTimeStep) {
+        this.currentTimeStep += 1;
       }
       if (should_pause) {
         this.paused = true;
@@ -147,7 +146,7 @@ export default {
         return;
       }
       this.dataLoaded = true;
-      this.maxTimeStep = num_timesteps - 1;
+      this.maxTimeStep = num_timesteps;
 
       // Setup polling to watch for new data.
       this.poll(itemId);
@@ -175,8 +174,7 @@ export default {
         try {
           const { data } = await this.girderRest.get(`/folder/${this.runId}`);
           if (data.hasOwnProperty('meta') && data.meta.hasOwnProperty('currentTimestep')) {
-            // Javascript arrays are 0-indexed but our simulation timesteps are 1-indexed.
-            var new_timestep = data.meta.currentTimestep - 1;
+            var new_timestep = data.meta.currentTimestep;
             if (new_timestep > this.maxTimeStep) {
               this.maxTimeStep = new_timestep;
             }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -23,7 +23,8 @@ v-app.app.pr-3
           v-layout
             template(v-for="j in numcols")
               v-flex(v-bind:style="{ width: cellWidth, height: cellHeight }")
-                image-gallery(:currentTimeStep.sync="currentTimeStep")
+                image-gallery(:currentTimeStep.sync="currentTimeStep"
+                              :maxTimeStep.sync="maxTimeStep")
       // Playback controls.
       div.playback-controls
         v-layout(row fluid).mt-0.mb-0
@@ -106,6 +107,7 @@ export default {
       numrows: 1,
       numcols: 1,
       paused: true,
+      runId: null,
     };
   },
 
@@ -133,19 +135,56 @@ export default {
     incrementTimeStep(should_pause) {
       this.currentTimeStep += 1;
       if (this.currentTimeStep > this.maxTimeStep) {
-        this.currentTimeStep = 0;
+        this.currentTimeStep = this.maxTimeStep;
       }
       if (should_pause) {
         this.paused = true;
       }
     },
 
-    initialDataLoaded(num_timesteps) {
+    initialDataLoaded(num_timesteps, itemId) {
       if (this.dataLoaded) {
         return;
       }
       this.dataLoaded = true;
       this.maxTimeStep = num_timesteps - 1;
+
+      // Setup polling to watch for new data.
+      this.poll(itemId);
+    },
+
+    lookupRunId(itemId) {
+      // Get the grandparent folder for this item. Its metadata will tell us
+      // what timestamps are available.
+      this.girderRest.get(`/item/${itemId}`)
+      .then((response) => {
+        return this.girderRest.get(`/folder/${response.data.folderId}`);
+      })
+      .then((response) => {
+        this.runId = response.data.parentId;
+        return this.poll(itemId);
+      });
+    },
+
+    poll(itemId) {
+      if (!this.runId) {
+        return this.lookupRunId(itemId);
+      }
+
+      this._poller = setTimeout(async () => {
+        try {
+          const { data } = await this.girderRest.get(`/folder/${this.runId}`);
+          if (data.hasOwnProperty('meta') && data.meta.hasOwnProperty('currentTimestep')) {
+            // Javascript arrays are 0-indexed but our simulation timesteps are 1-indexed.
+            var new_timestep = data.meta.currentTimestep - 1;
+            if (new_timestep > this.maxTimeStep) {
+              this.maxTimeStep = new_timestep;
+            }
+          }
+        } finally {
+          this.poll(itemId);
+        }
+      }, 10000);
     },
 
     removeColumn() {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -87,7 +87,7 @@ import {
 
 export default {
   name: 'App',
-  inject: ['girderRest'],
+  inject: ['girderRest', 'defaultLocation'],
 
   components: {
     GirderAuth,
@@ -234,7 +234,7 @@ export default {
         if (this.browserLocation) {
           return this.browserLocation;
         } else if (this.girderRest.user) {
-          return { _modelType: 'collection', _id: '5c5b42678d777f072b2f955c' };
+          return this.defaultLocation;
         }
         return null;
       },

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -124,7 +124,7 @@ export default {
       }
       // Load the current image and the next two.
       for (var i = this.step; i < this.step + 3; i++) {
-        if (i > this.maxTimeStep || i >= this.rows.length) {
+        if (i > this.maxTimeStep || i > this.rows.length) {
           break;
         }
 
@@ -137,7 +137,8 @@ export default {
           }
         }
         if (load_image) {
-          this.loadedImages.push({timestep: i, src: this.rows[i].img});
+          // Javascript arrays are 0-indexed but our simulation timesteps are 1-indexed.
+          this.loadedImages.push({timestep: i, src: this.rows[i - 1].img});
         }
       }
     },

--- a/client/src/components/ImageGallery.vue
+++ b/client/src/components/ImageGallery.vue
@@ -46,7 +46,7 @@ export default {
             name: val.name
           };
         }, this);
-        this.loadNextImages();
+        this.preCacheImages();
         // Not sure why this level of parent chaining is required
         // to get the app to be able to hear the event.
         this.$parent.$parent.$emit("data-loaded", this.rows.length);
@@ -59,7 +59,7 @@ export default {
     currentTimeStep: {
       immediate: true,
       handler () {
-        this.loadNextImages();
+        this.preCacheImages();
       }
     },
     itemId: {
@@ -82,7 +82,7 @@ export default {
       this.itemId = items[0];
     },
 
-    loadNextImages: function () {
+    preCacheImages: function () {
       // Return early if we haven't loaded the list of images from Girder yet.
       if (this.rows === null || this.rows.constructor !== Array || this.rows.length < 1) {
         return;

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,7 @@ vuetifyConfig.icons.logout = 'mdi-logout';
 Vue.use(Vuetify, vuetifyConfig);
 Vue.use(Girder);
 const girderRest = new RestClient({ apiRoot: `${window.location}/api/v1` });
+const defaultLocation = { _modelType: 'collection', _id: '5c5b42678d777f072b2f955c' };
 
 import App from './App.vue'
 
@@ -14,7 +15,7 @@ Vue.config.productionTip = false
 
 girderRest.fetchUser().then(() => {
   new Vue({
-    provide: { girderRest },
+    provide: { girderRest, defaultLocation },
     render: h => h(App),
   }).$mount('#app')
 });


### PR DESCRIPTION
Based on #11, poll for new data and show it as it arrives.

@cjh1 you'll notice that this PR does simple polling instead of using Girder EventSource notifications. I tried these out but they didn't seem to fit the bill:
1) There didn't seem to be any way to configure what you'll actually get notified about.
2) Notifications seem to be disabled on data.kitware.com.