### PR TITLE
Fix bug caused by removing plots

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -242,11 +242,13 @@ export default {
     },
 
     removeColumn() {
+      this.numLoadedGalleries -= this.numrows;
       this.numcols -= 1;
       this.updateCellWidth();
     },
 
     removeRow() {
+      this.numLoadedGalleries -= this.numcols;
       this.numrows -= 1;
       this.updateCellHeight();
     },


### PR DESCRIPTION
Removing a plot was not updating the current count of loaded galleries, creating
a bug that would cause the play option to stop working. Update the number of
loaded galleries on row or column removal.

Signed-off-by: Brianna Major <brianna.major@kitware.com>