### PR TITLE
Search param list

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -27,7 +27,6 @@
                                v-on:mouseout.native="hoverOut"
                                :location.sync="location"
                                :selectable="false"
-                               :new-folder-enabled="false"
                                :drag-enabled="true" />
           <!-- Playback controls. -->
           <v-container class="playback-controls pl-2 pr-1"
@@ -110,7 +109,7 @@
     <pane class="main-content"
           v-on:mouseover.native="hoverOut">
       <!-- image gallery grid. -->
-      <v-container v-bind:style="{padding: '0'}">
+      <v-container v-bind:style="{padding: '0', margin: '0', minWidth: '100%'}">
         <template v-for="i in numrows">
           <v-row v-bind:key="i">
             <template v-for="j in numcols">
@@ -139,7 +138,7 @@ import 'splitpanes/dist/splitpanes.css';
 import _ from 'lodash';
 import ImageGallery from './components/ImageGallery.vue';
 import { Authentication as GirderAuth } from '@girder/components/src/components';
-import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+import GirderFileManager from './components/GirderFileManager.vue';
 
 export default {
   name: 'App',

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -208,6 +208,9 @@ export default {
       }, 100),
 
     async getRangeData(event=null) {
+      if (this.location._modelType != 'folder')
+        return;
+
       const folderId = this.location._id;
       let img = null;
       if (!this.cancel) {
@@ -223,6 +226,9 @@ export default {
     },
 
     callEndpoints(folderId) {
+      if (!folderId)
+        return;
+
       var self = this;
       var endpoint = `item?folderId=${folderId}&name=${this.parameter}&limit=50&sort=lowerName&sortdir=1`;
       const data = this.girderRest.get(endpoint)

--- a/client/src/components/GirderDataBrowser.vue
+++ b/client/src/components/GirderDataBrowser.vue
@@ -1,0 +1,42 @@
+  <!-- This component extends the DataBrowser component in order to display a
+  filtered list of items when a search is being performed. -->
+
+<script>
+import { DataBrowser as GirderDataBrowser } from '@girder/components/src/components'
+import { getLocationType } from '@girder/components/src/utils';
+
+export default {
+  mixins: [GirderDataBrowser],
+
+  inject: ['girderRest'],
+
+  props: {
+    query: {
+      type: Array,
+      default: () => [],
+    },
+  },
+
+  methods: {
+    fetchPaginatedRows() {
+      if (this.query.length) {
+        return this.query;
+      }
+      const { location, counts } = this;
+      if (counts.nFolders || counts.nItems) {
+        return this.fetchPaginatedFolderRows();
+      }
+      const locationType = getLocationType(location);
+      if (locationType === 'users' || locationType === 'collections') {
+        if (counts.nUsers || counts.nCollections) {
+          const singularType = getSingularLocationTypeName(location);
+          return this.fetchPaginatedCollectionOrUserRows(singularType);
+        }
+      } else if (locationType === 'root') {
+        return this.generateRootRows();
+      }
+      return [];
+    }
+  }
+};
+</script>

--- a/client/src/components/GirderDataBrowser.vue
+++ b/client/src/components/GirderDataBrowser.vue
@@ -34,6 +34,12 @@ export default {
   },
 
   methods: {
+    refresh() {
+      this.selected = [];
+      this.internalRefreshCounter += 1;
+      this.options.page = 1;
+
+    },
     fetchPaginatedRows() {
       if (this.query.length) {
         const { options: { page, itemsPerPage } } = this;

--- a/client/src/components/GirderDataBrowser.vue
+++ b/client/src/components/GirderDataBrowser.vue
@@ -2,8 +2,11 @@
   filtered list of items when a search is being performed. -->
 
 <script>
-import { DataBrowser as GirderDataBrowser } from '@girder/components/src/components'
-import { getLocationType } from '@girder/components/src/utils';
+import { DataBrowser as GirderDataBrowser } from '@girder/components/src/components';
+import {
+  getLocationType,
+  getSingularLocationTypeName
+} from '@girder/components/src/utils';
 
 export default {
   mixins: [GirderDataBrowser],

--- a/client/src/components/GirderDataBrowser.vue
+++ b/client/src/components/GirderDataBrowser.vue
@@ -20,10 +20,26 @@ export default {
     },
   },
 
+  computed: {
+    serverItemsLength() {
+      if (this.query.length) {
+        return this.query.length;
+      } else {
+        return Object.values(this.counts).reduce(
+          (total, value) => total + value,
+          0,
+        );
+      }
+    }
+  },
+
   methods: {
     fetchPaginatedRows() {
       if (this.query.length) {
-        return this.query;
+        const { options: { page, itemsPerPage } } = this;
+        const itemOffset = itemsPerPage === -1 ? 0 : ((page - 1) * itemsPerPage);
+        const limit = itemsPerPage + itemOffset;
+        return this.query.slice(itemOffset, limit);
       }
       const { location, counts } = this;
       if (counts.nFolders || counts.nItems) {

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -1,10 +1,9 @@
 <script>
+import GirderDataBrowser from './GirderDataBrowser.vue';
 import {
-  DataBrowser as GirderDataBrowser,
   Breadcrumb as GirderBreadcrumb,
 } from '@girder/components/src/components';
 import {
-  getLocationType,
   isRootLocation,
   createLocationValidator,
 } from '@girder/components/src/utils';
@@ -70,6 +69,13 @@ export default {
         this.filterResults();
       },
     },
+    queryValues: {
+      get () {
+        if (this.query)
+          return [this.query.value];
+        return [];
+      }
+    },
   },
   async created() {
     if (!createLocationValidator(!this.rootLocationDisabled)(this.internalLocation)) {
@@ -78,6 +84,14 @@ export default {
     await this.setCurrentPath();
     await this.getAllResults(this.location._id);
     this.filteredItems = this.allItems;
+  },
+  watch: {
+    async query() {
+      if (this.query) {
+        let { data } = await this.girderRest.get(`/folder/${this.query.value.folderId}`);
+        this.internalLocation = data;
+      }
+    },
   },
   methods: {
     isRootLocation,
@@ -143,6 +157,7 @@ export default {
       :value="value"
       :initial-items-per-page="initialItemsPerPage"
       :items-per-page-options="itemsPerPageOptions"
+      :query="queryValues"
       @input="$emit('input', $event)"
       @selection-changed="$emit('selection-changed', $event)"
       @rowclick="$emit('rowclick', $event)"

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -47,9 +47,11 @@ export default {
   data() {
     return {
       lazyLocation: null,
+      previousLocation: null,
       query: null,
       allItems: [],
       filteredItems: [],
+      input: '',
     };
   },
   computed: {
@@ -89,6 +91,7 @@ export default {
     async query() {
       if (this.query) {
         let { data } = await this.girderRest.get(`/folder/${this.query.value.folderId}`);
+        this.previousLocation = this.lazyLocation;
         this.internalLocation = data;
       }
     },
@@ -180,11 +183,13 @@ export default {
             v-model="query"
             :items="filteredItems"
             :append-outer-icon=" 'search' "
+            :search.input.sync="input"
             placeholder="Search for Parameter"
             return-object
             clearable
             dense
-            solo/>
+            solo
+            @click:clear="clear"/>
       </template>
       <template #row-widget="props">
         <slot

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -153,7 +153,7 @@ export default {
 </script>
 
 <template>
-  <v-card v-bind:class="[query ? 'queryResults' : '','girder-data-browser-snippet']">
+  <v-card class="girder-data-browser-snippet">
     <girder-data-browser
       ref="girderBrowser"
       :location.sync="internalLocation"

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -152,8 +152,7 @@ export default {
         this.showPartials = true;
       }
       if (this.$refs.query.isMenuActive) {
-        this.$refs.query.isMenuActive = false;
-        this.$refs.query.focus();
+        this.$refs.query.blur();
       }
     },
   },
@@ -203,7 +202,13 @@ export default {
             @click:append="clear"
             @click:append-outer="showMatches"
             @keyup.enter="showMatches"
-            v-bind:class="[outsideOfRoot ? 'hide-search' : '']" />
+            v-bind:class="[outsideOfRoot ? 'hide-search' : '']">
+          <template v-slot:no-data>
+            <v-list-item dense v-bind:style="{fontSize: '0.8rem'}">
+              No Matches Found
+            </v-list-item>
+          </template>
+        </v-combobox>
       </template>
       <template #row-widget="props">
         <slot

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -67,14 +67,16 @@ export default {
       }
       if (!this.showPartials && this.query) {
         let { data } = await this.girderRest.get(`/folder/${this.query.value.folderId}`);
-        this.previousLocation = this.lazyLocation;
-        this.internalLocation = data;
+        this.internalLocation = {...data, 'search': true};
       }
     },
     showPartials() {
       this.refresh();
     },
     internalLocation() {
+      if (!this.lazyLocation.hasOwnProperty('search')) {
+        this.clear();
+      }
       this.filterResults();
     }
   },

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -41,12 +41,10 @@ export default {
               return item.value.name.includes(this.input ? this.input : '');
             })
             .map(item => { return {...item.value, 'name': item.text}; });
-          if (!this.input) {
-            this.input = ' ';
-            this.$refs.query.blur();
+            if (!this.input)
+              this.$refs.query.blur();
+            return values;
           }
-          return values;
-        }
         return [];
       }
     },
@@ -60,12 +58,13 @@ export default {
 
   watch: {
     async query() {
-      if (this.query != this.input) {
-        this.showPartials = false;
-      } else if (this.input && this.query == this.input){
+      if (this.input === '' || this.input && !typeof(this.query) == 'object'){
         this.showPartials = true;
+      } else if (typeof(this.query) == 'object') {
+        this.showPartials = false;
       }
-      if (!this.showPartials && this.query) {
+      this.refresh();
+      if (!this.showPartials && typeof(this.query) == 'object') {
         let { data } = await this.girderRest.get(`/folder/${this.query.value.folderId}`);
         this.internalLocation = {...data, 'search': true};
       }
@@ -194,16 +193,16 @@ export default {
             ref="query"
             v-model="query"
             :items="filteredItems"
+            :append-icon=" 'clear' "
             :append-outer-icon=" 'search' "
-            @click:append-outer="showMatches"
-            @keyup.enter="showMatches"
             :search-input.sync="input"
             placeholder="Search for Parameter"
             return-object
-            clearable
             dense
             solo
-            @click:clear="clear"
+            @click:append="clear"
+            @click:append-outer="showMatches"
+            @keyup.enter="showMatches"
             v-bind:class="[outsideOfRoot ? 'hide-search' : '']" />
       </template>
       <template #row-widget="props">

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -1,76 +1,32 @@
+<!-- This component extends the FileManager component in order to provide a
+search bar and to collect and filter parameter options. -->
+
 <script>
+import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
 import GirderDataBrowser from './GirderDataBrowser.vue';
 import {
   Breadcrumb as GirderBreadcrumb,
 } from '@girder/components/src/components';
-import {
-  isRootLocation,
-  createLocationValidator,
-} from '@girder/components/src/utils';
 export default {
   components: {
     GirderBreadcrumb,
     GirderDataBrowser,
   },
-  props: {
-    value: {
-      type: Array,
-      default: () => [],
-    },
-    location: {
-      type: Object,
-      validator: createLocationValidator(true),
-      default: null,
-    },
-    rootLocationDisabled: {
-      type: Boolean,
-      default: false,
-    },
-    selectable: {
-      type: Boolean,
-      default: false,
-    },
-    dragEnabled: {
-      type: Boolean,
-      default: false,
-    },
-    initialItemsPerPage: {
-      type: Number,
-      default: 10,
-    },
-    itemsPerPageOptions: {
-      type: Array,
-      default: () => ([10, 25, 50]),
-    },
-  },
+
+  mixins: [GirderFileManager],
+
   inject: ['girderRest'],
+
   data() {
     return {
-      lazyLocation: null,
-      previousLocation: null,
       query: null,
       allItems: [],
       filteredItems: [],
       input: '',
     };
   },
+
   computed: {
-    internalLocation: {
-      get() {
-        const { location, lazyLocation } = this;
-        if (location) {
-          return location;
-        } if (lazyLocation) {
-          return lazyLocation;
-        }
-        return { type: 'root' };
-      },
-      set(newVal) {
-        this.lazyLocation = newVal;
-        this.$emit('update:location', newVal);
-        this.filterResults();
-      },
-    },
     queryValues: {
       get () {
         if (this.query)
@@ -79,14 +35,13 @@ export default {
       }
     },
   },
+
   async created() {
-    if (!createLocationValidator(!this.rootLocationDisabled)(this.internalLocation)) {
-      throw new Error('root location cannot be used when root-location-disabled is true');
-    }
     await this.setCurrentPath();
     await this.getAllResults(this.location._id);
     this.filteredItems = this.allItems;
   },
+
   watch: {
     async query() {
       if (this.query) {
@@ -95,12 +50,12 @@ export default {
         this.internalLocation = data;
       }
     },
+    internalLocation() {
+      this.filterResults();
+    }
   },
+
   methods: {
-    isRootLocation,
-    refresh() {
-      this.$refs.girderBrowser.refresh();
-    },
     async setCurrentPath(){
       var location = this.lazyLocation;
       if (!this.lazyLocation) {

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -155,7 +155,10 @@ export default {
         this.$refs.query.isMenuActive = false;
         this.$refs.query.focus();
       }
-    }
+    },
+    customFilter(item, queryText) {
+      return item.value.name.includes(queryText ? queryText : '');
+    },
   },
 };
 </script>
@@ -196,6 +199,7 @@ export default {
             :append-icon=" 'clear' "
             :append-outer-icon=" 'search' "
             :search-input.sync="input"
+            :filter="customFilter"
             placeholder="Search for Parameter"
             return-object
             dense

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -73,6 +73,11 @@ export default {
     showPartials() {
       this.refresh();
     },
+    input() {
+      if (this.input == '') {
+        this.clear();
+      }
+    },
     internalLocation() {
       if (!this.lazyLocation.hasOwnProperty('search')) {
         this.clear();
@@ -139,6 +144,8 @@ export default {
     },
     clear() {
       this.showPartials = false;
+      this.query = null;
+      this.input = '';
       this.refresh();
     },
     showMatches() {

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -1,0 +1,169 @@
+<script>
+import {
+  DataBrowser as GirderDataBrowser,
+  Breadcrumb as GirderBreadcrumb,
+} from '@girder/components/src/components';
+import {
+  getLocationType,
+  isRootLocation,
+  createLocationValidator,
+} from '@girder/components/src/utils';
+export default {
+  components: {
+    GirderBreadcrumb,
+    GirderDataBrowser,
+  },
+  props: {
+    value: {
+      type: Array,
+      default: () => [],
+    },
+    location: {
+      type: Object,
+      validator: createLocationValidator(true),
+      default: null,
+    },
+    rootLocationDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    selectable: {
+      type: Boolean,
+      default: false,
+    },
+    dragEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    initialItemsPerPage: {
+      type: Number,
+      default: 10,
+    },
+    itemsPerPageOptions: {
+      type: Array,
+      default: () => ([10, 25, 50]),
+    },
+  },
+  inject: ['girderRest'],
+  data() {
+    return {
+      lazyLocation: null,
+      model: '',
+      allItems: [],
+      filteredItems: [],
+      loading: false,
+    };
+  },
+  computed: {
+    internalLocation: {
+      get() {
+        const { location, lazyLocation } = this;
+        if (location) {
+          return location;
+        } if (lazyLocation) {
+          return lazyLocation;
+        }
+        return { type: 'root' };
+      },
+      set(newVal) {
+        this.lazyLocation = newVal;
+        this.allItems = [];
+        this.$emit('update:location', newVal);
+        this.filterResults();
+      },
+    },
+  },
+  created() {
+    if (!createLocationValidator(!this.rootLocationDisabled)(this.internalLocation)) {
+      throw new Error('root location cannot be used when root-location-disabled is true');
+    }
+    this.filterResults();
+  },
+  methods: {
+    isRootLocation,
+    refresh() {
+      this.$refs.girderBrowser.refresh();
+    },
+    async getResults(folderId) {
+      var details = await this.girderRest.get(`folder/${folderId}/details`);
+      if (details.data.nItems > 0) {
+        var items = await this.girderRest
+          .get(`/item?folderId=${folderId}&sort=lowerName&sortdir=1`);
+        items.data.forEach(async item => {
+          var { data } = await this.girderRest
+            .get(`/resource/${item._id}/path?type=item`);
+          var path = data.split(this.currentFolder + '/')[1];
+          this.allItems.push(path.substring(path.indexOf('/')+1));
+        });
+      }
+      if (details.data.nFolders > 0) {
+        var folders = await this.girderRest
+          .get(`/folder?parentType=folder&parentId=${folderId}&sort=lowerName&sortdir=1`);
+        for (var idx in folders.data) {
+          await this.getResults(folders.data[idx]._id);
+        }
+      }
+    },
+    async filterResults() {
+      let { data } = await this.girderRest.get(`/${this.location._modelType}/${this.location._id}`);
+      this.currentFolder = data.name;
+      this.loading = true;
+      await this.getResults(this.location._id);
+      this.loading = false;
+      this.filteredItems = await this.allItems.filter(item => {return item.includes(this.model)});
+    },
+    submitSearch() {
+      return;
+    },
+  },
+};
+</script>
+
+<template>
+  <v-card class="girder-data-browser-snippet">
+    <girder-data-browser
+      ref="girderBrowser"
+      :location.sync="internalLocation"
+      :selectable="selectable"
+      :draggable="dragEnabled"
+      :root-location-disabled="rootLocationDisabled"
+      :value="value"
+      :initial-items-per-page="initialItemsPerPage"
+      :items-per-page-options="itemsPerPageOptions"
+      @input="$emit('input', $event)"
+      @selection-changed="$emit('selection-changed', $event)"
+      @rowclick="$emit('rowclick', $event)"
+      @drag="$emit('drag', $event)"
+      @dragstart="$emit('dragstart', $event)"
+      @dragend="$emit('dragend', $event)"
+      @drop="$emit('drop', $event)"
+    >
+      <template #breadcrumb="props">
+        <girder-breadcrumb
+          :location="props.location"
+          :root-location-disabled="props.rootLocationDisabled"
+          @crumbclick="props.changeLocation($event)"
+        />
+      </template>
+      <template #headerwidget="props">
+        <slot name="headerwidget" />
+        <v-autocomplete
+            ref="model"
+            v-model="model"
+            :items="allItems"
+            clearable
+            dense
+            solo
+            placeholder="Search for Parameter"
+            @click:append-outer="submitSearch"
+            :append-outer-icon=" 'search' " />
+      </template>
+      <template #row-widget="props">
+        <slot
+          v-bind="props"
+          name="row-widget"
+        />
+      </template>
+    </girder-data-browser>
+  </v-card>
+</template>

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -156,9 +156,6 @@ export default {
         this.$refs.query.focus();
       }
     },
-    customFilter(item, queryText) {
-      return item.value.name.includes(queryText ? queryText : '');
-    },
   },
 };
 </script>
@@ -199,7 +196,6 @@ export default {
             :append-icon=" 'clear' "
             :append-outer-icon=" 'search' "
             :search-input.sync="input"
-            :filter="customFilter"
             placeholder="Search for Parameter"
             return-object
             dense

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -32,7 +32,7 @@ export default {
   computed: {
     queryValues: {
       get () {
-        if (this.query && !this.showPartials) {
+        if (this.query && this.query.hasOwnProperty('value') && !this.showPartials) {
           return [this.query.value];
         }
         else if (this.showPartials) {

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -142,15 +142,18 @@ export default {
         }
       });
     },
-    submitSearch() {
-      return;
+    clear() {
+      if (this.query) {
+        this.internalLocation = this.previousLocation;
+        this.previousLocation = null;
+      }
     },
   },
 };
 </script>
 
 <template>
-  <v-card class="girder-data-browser-snippet">
+  <v-card v-bind:class="[query ? 'queryResults' : '','girder-data-browser-snippet']">
     <girder-data-browser
       ref="girderBrowser"
       :location.sync="internalLocation"

--- a/client/src/components/GirderFileManager.vue
+++ b/client/src/components/GirderFileManager.vue
@@ -202,6 +202,7 @@ export default {
             @click:append="clear"
             @click:append-outer="showMatches"
             @keyup.enter="showMatches"
+            @keyup.esc="$refs.query.blur()"
             v-bind:class="[outsideOfRoot ? 'hide-search' : '']">
           <template v-slot:no-data>
             <v-list-item dense v-bind:style="{fontSize: '0.8rem'}">

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -101,8 +101,16 @@
   align-items: baseline;
 }
 
-.hide-search.v-input {
-  display: none;
+// Prevent default rotation of clear icon
+.v-select.v-select--is-menu-active
+  .v-input__icon--append
+  .v-icon {
+  transform: rotate(0);
+}
+
+.theme--light.v-list-item .v-list-item__mask {
+  color: inherit;
+  background: inherit;
 }
 
 // Align Rows per page footer

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -108,11 +108,6 @@
   transform: rotate(0);
 }
 
-.theme--light.v-list-item .v-list-item__mask {
-  color: inherit;
-  background: inherit;
-}
-
 // Align Rows per page footer
 .v-data-footer {
   justify-content: center;

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -116,3 +116,14 @@ table.v-table tbody td {
 .gtitle, .ytitle, .xtitle {
   font-size: inherit !important;
 }
+
+.v-text-field__details {
+  display: none;
+}
+
+.v-input__control {
+  margin-top: 20px;
+}
+ .v-input__append-outer {
+   margin-top: 27px !important;
+ }

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -106,12 +106,6 @@
   justify-content: center;
 }
 
-.queryResults {
-  .v-data-footer > div {
-    display: none;
-  }
-}
-
 // Make sure toolbar doesn't cover plot title
 // when visible
 .show-toolbar {

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -101,6 +101,10 @@
   align-items: baseline;
 }
 
+.hide-search.v-input {
+  display: none;
+}
+
 // Align Rows per page footer
 .v-data-footer {
   justify-content: center;

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -106,6 +106,12 @@
   justify-content: center;
 }
 
+.queryResults {
+  .v-data-footer > div {
+    display: none;
+  }
+}
+
 // Make sure toolbar doesn't cover plot title
 // when visible
 .show-toolbar {

--- a/client/src/scss/gallery.scss
+++ b/client/src/scss/gallery.scss
@@ -137,3 +137,7 @@
 .gtitle, .ytitle, .xtitle {
   font-size: inherit !important;
 }
+
+.v-text-field__details {
+  display: none;
+}


### PR DESCRIPTION
This PR adds in a search bar for locating parameters by name. When the dashboard is initially loaded the entire tree is searched and a master list of all parameters is made. Navigating up or down the tree and typing a name into the search bar will filter that list down. Simply clicking in the search box will display a drop-down menu of every parameter available under the current location, and the list will be filtered as the parameter name is typed.

Pressing `enter` or clicking the search icon will update the data browser table to display all parameters that match the current search criteria, and those parameters can be dragged and dropped into the plot grid as usual. The parameter names will include the current path as well in order to differentiate between any parameters that may have the same name but are found in different locations.

Clicking on a suggested parameter from the drop-down menu (either using the mouse or up/down arrow keys and `enter`) will update the location to the directory that that parameter is located in, and the data browser will be updated to display only that parameter. This can then be added to the plot grid as usual by dragging and dropping the parameter name.

Addresses #19 